### PR TITLE
02_generatorファイルの作成

### DIFF
--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,14 @@
+Rails.application.config.generators do |g|
+  g.skip_routes true     # trueならroutes.rb変更せず、falseなら通常通り変更
+  g.assets false          # assetsを生成しない
+  g.stylesheets false    # スタイルシートを生成しない
+  g.helper false         # helperを生成しない
+  g.template_engine :erb                 # テンプレートにはerbを利用する 他にはslim,hamlなど
+  g.test_framework :rspec,               # RSpecを使う
+                   fixtures: true,       
+                   view_specs: false,
+                   routing_specs: false,
+                   helper_specs: false,
+                   controller_specs: false, 
+                   request_specs: true
+end


### PR DESCRIPTION
## 概要

rails generate時に自動生成されるファイルを定義するため、generators.rbファイルを作成する。

## ブランチ

future/createGenerator

## 内容

以下の内容で`config/initializers/generators.rb`を作成。

- controller作成時などにroute.rbを変更しない(パラメータ：skip_routes)
- assets配下のファイルを自動生成しない(パラメータ：assets)
- stylesheetsを自動生成しない(パラメータ：stylesheets)
- helperを自動生成しない（パラメータ：helper)
- テンプレートファイルはerbで作成する（パラメータ：template_engine)
- テストフレームワークはrspecを使用し、fixtures, request_specsを自動生成する(パラメータ： test_framework)

## 参考資料

[rails generateで自動生成されるファイルの設定 - Qiita](https://qiita.com/kodai_0122/items/14494a3848654f32909d)